### PR TITLE
selinux: fix module build on RHEL != 5

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -17,10 +17,6 @@ class selinux::base {
   case $::osfamily {
     RedHat: {
 
-      package{ 'selinux-policy-devel':
-        ensure => present,
-      }
-
       case $::lsbmajdistrelease {
 
         '6': {
@@ -31,6 +27,10 @@ class selinux::base {
         }
 
         '5': {
+
+          package{ 'selinux-policy-devel':
+            ensure => present,
+          }
 
           case $::lsbdistrelease {
             /^5.0$/, /^5.1$/, /^5.2$/, /^5.3$/: {

--- a/manifests/module/redhat.pp
+++ b/manifests/module/redhat.pp
@@ -2,7 +2,7 @@
 # == Definition: selinux::module::redhat
 #
 # This definition builds a binary SELinux module with the Makefile provided by
-# the selinux-policy-devel package.
+# the selinux-policy-devel or selinux-policy package.
 # It should only be called ba the selinux::module definition, in case of
 # RedHat osfamily.
 #
@@ -43,10 +43,14 @@ define selinux::module::redhat (
     notify  => Exec["build selinux policy package ${name}"],
   }
 
+  $build_reqs = $lsbmajdistrelease  ? {
+    '5'     => [File["${dest}/${name}.te"], Package['checkpolicy'], Package ['selinux-policy-devel']],
+    default => [File["${dest}/${name}.te"], Package['checkpolicy']],
+  }
   exec { "build selinux policy package ${name}":
     cwd     => $dest,
     command => "make -f /usr/share/selinux/devel/Makefile ${name}.pp",
-    require => [File["${dest}/${name}.te"], Package['checkpolicy'], Package['selinux-policy-devel']],
+    require => $build_reqs,
   }
 
 }


### PR DESCRIPTION
The selinux-policy-devel package exists only on rhel5 (not 4, not 6).
