### PR TITLE
Allow file context source in module

### DIFF
--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -31,6 +31,7 @@ define selinux::module (
   $dest='/usr/share/selinux/targeted/',
   $content=undef,
   $source=undef,
+  $withfc=false,
   $load=true,
 ) {
 
@@ -44,6 +45,7 @@ define selinux::module (
         dest    => $dest,
         content => $content,
         source  => $source,
+        withfc  => $withfc,
         load    => $load,
       }
     }


### PR DESCRIPTION
A module can have a NAME.fc file to define file context. I think it provide better integration than an selinux::fcontext definition.
This pr add the option to have this file.
TODO: debian part
