### PR TITLE
fcontext: launch restorecon on real path

### DIFF
--- a/manifests/fcontext.pp
+++ b/manifests/fcontext.pp
@@ -50,14 +50,16 @@ define selinux::fcontext(
       $grep     = '! egrep -q'
   }
 
+  $path_rc = regsubst( $path, '$(.*)\(.*', '\1' )
+
   exec { "semanage fcontext ${setype} ${path}${path_glob}":
     path    => '/usr/bin:/usr/sbin:/bin:/sbin',
     command => "semanage fcontext -a -t ${setype} \"${path}${path_glob}\"",
     unless  => "semanage fcontext --list | ( ${grep} '${re}' >/dev/null)",
   } ~>
-  exec { "restorecon -R ${path}":
+  exec { "restorecon -R ${path_rc}":
     path        => '/usr/bin:/usr/sbin:/bin:/sbin',
-    command     => "restorecon -R ${path}",
+    command     => "restorecon -R ${path_rc}",
     refreshonly => $refreshonly,
   }
 

--- a/manifests/fcontext.pp
+++ b/manifests/fcontext.pp
@@ -57,7 +57,7 @@ define selinux::fcontext(
     command => "semanage fcontext -a -t ${setype} \"${path}${path_glob}\"",
     unless  => "semanage fcontext --list | ( ${grep} '${re}' >/dev/null)",
   } ~>
-  exec { "restorecon -R ${path_rc}":
+  exec { "restorecon -R ${path}":
     path        => '/usr/bin:/usr/sbin:/bin:/sbin',
     command     => "restorecon -R ${path_rc}",
     refreshonly => $refreshonly,

--- a/manifests/fcontext.pp
+++ b/manifests/fcontext.pp
@@ -50,7 +50,7 @@ define selinux::fcontext(
       $grep     = '! egrep -q'
   }
 
-  $path_rc = regsubst( $path, '$(.*)\(.*', '\1' )
+  $path_rc = regsubst( $path, '^(.*)\(.*', '\1' )
 
   exec { "semanage fcontext ${setype} ${path}${path_glob}":
     path    => '/usr/bin:/usr/sbin:/bin:/sbin',


### PR DESCRIPTION
Try to resolve:
https://github.com/camptocamp/puppet-selinux/issues/27

Looks for the path on the left on a "(".
Maybe we should consider a ".*" in the path, an not only "(.*)" ?