### PR TITLE
Use a separate source or content for file context

### DIFF
--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -40,7 +40,7 @@ define selinux::module (
   validate_bool($load)
 
   if str2bool($withfc) == true {
-    fail("${name} : \$withfc is deprecated. Use contentfc or sourcefc instead!")
+    warning("${name} : \$withfc is deprecated. Use contentfc or sourcefc instead!")
   }
 
   case $::osfamily {
@@ -53,6 +53,7 @@ define selinux::module (
         source    => $source,
         contentfc => $contentfc,
         sourcefc  => $sourcefc,
+        withfc    => $withfc,
         load      => $load,
       }
     }

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -31,22 +31,29 @@ define selinux::module (
   $dest='/usr/share/selinux/targeted/',
   $content=undef,
   $source=undef,
+  $contentfc=undef,
+  $sourcefc=undef,
   $withfc=false,
   $load=true,
 ) {
 
   validate_bool($load)
 
+  if str2bool($withfc) == true {
+    fail("${name} : \$withfc is deprecated. Use contentfc or sourcefc instead!")
+  }
+
   case $::osfamily {
 
     'RedHat': {
       selinux::module::redhat{ $name:
-        ensure  => $ensure,
-        dest    => $dest,
-        content => $content,
-        source  => $source,
-        withfc  => $withfc,
-        load    => $load,
+        ensure    => $ensure,
+        dest      => $dest,
+        content   => $content,
+        source    => $source,
+        contentfc => $contentfc,
+        sourcefc  => $sourcefc,
+        load      => $load,
       }
     }
 

--- a/manifests/module/redhat.pp
+++ b/manifests/module/redhat.pp
@@ -25,6 +25,7 @@ define selinux::module::redhat (
   $source=undef,
   $contentfc=undef,
   $sourcefc=undef,
+  $withfc=false,
   $load=true,
 ) {
 
@@ -47,6 +48,21 @@ define selinux::module::redhat (
           ensure  => file,
           content => $contentfc,
           source  => $sourcefc,
+          owner   => 'root',
+          group   => 'root',
+          mode    => '0644',
+          notify  => Exec["build selinux policy package ${name} if source changed"],
+        }
+      } elsif $withfc {
+        $_sourcefc = $sourcefc ? {
+          undef   => undef,
+          default => regsubst( $source, '(.*)\.te', '\1.fc' ),
+        }
+
+        file{ "${dest}/${name}.fc":
+          ensure  => file,
+          content => $contentfc,
+          source  => $_sourcefc,
           owner   => 'root',
           group   => 'root',
           mode    => '0644',

--- a/manifests/module/redhat.pp
+++ b/manifests/module/redhat.pp
@@ -15,15 +15,16 @@
 #   "/usr/share/selinux/targeted/"
 # - *content*: inline content or template of the module source
 # - *source*: file:// or puppet:// URI of the module source file
-# - *withfc*: true if there is a file context source file
-#
+# - *contentfc*: inline content or template of the module file context source
+# - *sourcefc*: file:// or puppet:// URI of the module file context source file
 #
 define selinux::module::redhat (
   $ensure=present,
   $dest='/usr/share/selinux/targeted/',
   $content=undef,
   $source=undef,
-  $withfc=false,
+  $contentfc=undef,
+  $sourcefc=undef,
   $load=true,
 ) {
 
@@ -41,15 +42,11 @@ define selinux::module::redhat (
       }
 
       # if there is source for file context configuration
-      if $withfc {
-        $_source = $source ? {
-          undef   => undef,
-          default => regsubst( $source, '(.*)\.te', '\1.fc' ),
-        }
+      if $sourcefc or $contentfc {
         file{ "${dest}/${name}.fc":
           ensure  => file,
-          content => $content,
-          source  => $_source,
+          content => $contentfc,
+          source  => $sourcefc,
           owner   => 'root',
           group   => 'root',
           mode    => '0644',


### PR DESCRIPTION
This patch allow to use a specific source or content for the file context (.fc) of a module.
It keep backward compatibility, but 628e396 should be reverted in a future release.